### PR TITLE
Feature: Support `Request::setFactory`

### DIFF
--- a/Factory/HttpFoundationFactory.php
+++ b/Factory/HttpFoundationFactory.php
@@ -35,15 +35,18 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
         $parsedBody = $psrRequest->getParsedBody();
         $parsedBody = is_array($parsedBody) ? $parsedBody : array();
 
-        $request = new Request(
-            $psrRequest->getQueryParams(),
-            $parsedBody,
-            $psrRequest->getAttributes(),
+        $request = Request::create(
+            $psrRequest->getUri(),
+            $psrRequest->getMethod(),
+            array(),
             $psrRequest->getCookieParams(),
             $this->getFiles($psrRequest->getUploadedFiles()),
             $psrRequest->getServerParams(),
             $psrRequest->getBody()->__toString()
         );
+        $request->request->replace($parsedBody);
+        $request->query->replace($psrRequest->getQueryParams());
+        $request->attributes->replace($psrRequest->getAttributes());
         $request->headers->replace($psrRequest->getHeaders());
 
         return $request;

--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -17,16 +17,17 @@ use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\Response;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\ServerRequest;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\Stream;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 class HttpFoundationFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    /** @type HttpFoundationFactory */
+    /** @var HttpFoundationFactory */
     private $factory;
 
-    /** @type string */
+    /** @var string */
     private $tmpDir;
 
     public function setup()
@@ -212,4 +213,21 @@ class HttpFoundationFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('The response body', $symfonyResponse->getContent());
         $this->assertEquals(200, $symfonyResponse->getStatusCode());
     }
+
+    public function testUsesRequestFactoryToCreateSymfonyRequestObjects()
+    {
+        if (!method_exists('\Symfony\Component\HttpFoundation\Request', 'setFactory')) {
+            $this->markTestSkipped('Symfony Request::setFactory not supported.');
+        }
+
+        $symfony_request = new Request();
+        Request::setFactory(function() use ($symfony_request) {
+            return $symfony_request;
+        });
+
+        $request = new \Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\ServerRequest();
+
+        $this->assertSame($symfony_request, $this->factory->createRequest($request));
+    }
+
 }

--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -23,7 +23,10 @@ use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\UploadedFile;
  */
 class HttpFoundationFactoryTest extends \PHPUnit_Framework_TestCase
 {
+    /** @type HttpFoundationFactory */
     private $factory;
+
+    /** @type string */
     private $tmpDir;
 
     public function setup()
@@ -62,11 +65,12 @@ class HttpFoundationFactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         $symfonyRequest = $this->factory->createRequest($serverRequest);
+        $files = $symfonyRequest->files->all();
 
         $this->assertEquals('http://les-tilleuls.coop', $symfonyRequest->query->get('url'));
-        $this->assertEquals('doc1.txt', $symfonyRequest->files->get('doc1')->getClientOriginalName());
-        $this->assertEquals('doc2.txt', $symfonyRequest->files->get('nested[docs][0]', null, true)->getClientOriginalName());
-        $this->assertEquals('doc3.txt', $symfonyRequest->files->get('nested[docs][1]', null, true)->getClientOriginalName());
+        $this->assertEquals('doc1.txt', $files['doc1']->getClientOriginalName());
+        $this->assertEquals('doc2.txt', $files['nested']['docs'][0]->getClientOriginalName());
+        $this->assertEquals('doc3.txt', $files['nested']['docs'][1]->getClientOriginalName());
         $this->assertEquals('http://dunglas.fr', $symfonyRequest->request->get('url'));
         $this->assertEquals($stdClass, $symfonyRequest->attributes->get('custom'));
         $this->assertEquals('Lille', $symfonyRequest->cookies->get('city'));


### PR DESCRIPTION
This commit makes it possible to use `Request::setFactory` to change the class that is returned from this bridge. This is useful when bridging to a wrapped request.

Resolves #12 