### PR TITLE
Remove use of deprecated 'deep' parameter in tests

### DIFF
--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -23,7 +23,10 @@ use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\UploadedFile;
  */
 class HttpFoundationFactoryTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var HttpFoundationFactory */
     private $factory;
+
+    /** @var string */
     private $tmpDir;
 
     public function setup()
@@ -62,11 +65,12 @@ class HttpFoundationFactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         $symfonyRequest = $this->factory->createRequest($serverRequest);
+        $files = $symfonyRequest->files->all();
 
         $this->assertEquals('http://les-tilleuls.coop', $symfonyRequest->query->get('url'));
-        $this->assertEquals('doc1.txt', $symfonyRequest->files->get('doc1')->getClientOriginalName());
-        $this->assertEquals('doc2.txt', $symfonyRequest->files->get('nested[docs][0]', null, true)->getClientOriginalName());
-        $this->assertEquals('doc3.txt', $symfonyRequest->files->get('nested[docs][1]', null, true)->getClientOriginalName());
+        $this->assertEquals('doc1.txt', $files['doc1']->getClientOriginalName());
+        $this->assertEquals('doc2.txt', $files['nested']['docs'][0]->getClientOriginalName());
+        $this->assertEquals('doc3.txt', $files['nested']['docs'][1]->getClientOriginalName());
         $this->assertEquals('http://dunglas.fr', $symfonyRequest->request->get('url'));
         $this->assertEquals($stdClass, $symfonyRequest->attributes->get('custom'));
         $this->assertEquals('Lille', $symfonyRequest->cookies->get('city'));


### PR DESCRIPTION
This allows the tests to complete when using the symfony 3.0 version of http-foundation.