### PR TITLE
Allow multiple calls to Request::getContent()

### DIFF
--- a/Factory/DiactorosFactory.php
+++ b/Factory/DiactorosFactory.php
@@ -45,7 +45,7 @@ class DiactorosFactory implements HttpMessageFactoryInterface
         $server = DiactorosRequestFactory::normalizeServer($symfonyRequest->server->all());
         $headers = $symfonyRequest->headers->all();
 
-        if(PHP_VERSION_ID < 50600) {
+        if (PHP_VERSION_ID < 50600) {
             $body = new DiactorosStream('php://temp', 'wb+');
             $body->write($symfonyRequest->getContent());
         } else {

--- a/Factory/DiactorosFactory.php
+++ b/Factory/DiactorosFactory.php
@@ -45,11 +45,11 @@ class DiactorosFactory implements HttpMessageFactoryInterface
         $server = DiactorosRequestFactory::normalizeServer($symfonyRequest->server->all());
         $headers = $symfonyRequest->headers->all();
 
-        try {
-            $body = new DiactorosStream($symfonyRequest->getContent(true));
-        } catch (\LogicException $e) {
+        if(PHP_VERSION_ID < 50600) {
             $body = new DiactorosStream('php://temp', 'wb+');
             $body->write($symfonyRequest->getContent());
+        } else {
+            $body = new DiactorosStream($symfonyRequest->getContent(true));
         }
 
         $request = new ServerRequest(

--- a/Tests/Factory/DiactorosFactoryTest.php
+++ b/Tests/Factory/DiactorosFactoryTest.php
@@ -112,6 +112,16 @@ class DiactorosFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('2.8'), $psrRequest->getHeader('X-Symfony'));
     }
 
+    public function testGetContentCanBeCalledAfterRequestCreation()
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array(), 'Content');
+
+        $psrRequest = $this->factory->createRequest($request);
+
+        $this->assertEquals('Content', $psrRequest->getBody()->__toString());
+        $this->assertEquals('Content', $request->getContent());
+    }
+
     private function createUploadedFile($content, $originalName, $mimeType, $error)
     {
         $path = tempnam($this->tmpDir, uniqid());

--- a/Tests/Factory/DiactorosFactoryTest.php
+++ b/Tests/Factory/DiactorosFactoryTest.php
@@ -75,7 +75,6 @@ class DiactorosFactoryTest extends \PHPUnit_Framework_TestCase
         $psrRequest = $this->factory->createRequest($request);
 
         $this->assertEquals('Content', $psrRequest->getBody()->__toString());
-        $this->assertEquals('Content', $request->getContent()); // check if getContent() can be called multiple times
 
         $queryParams = $psrRequest->getQueryParams();
         $this->assertEquals('1', $queryParams['foo']);

--- a/Tests/Factory/DiactorosFactoryTest.php
+++ b/Tests/Factory/DiactorosFactoryTest.php
@@ -75,6 +75,7 @@ class DiactorosFactoryTest extends \PHPUnit_Framework_TestCase
         $psrRequest = $this->factory->createRequest($request);
 
         $this->assertEquals('Content', $psrRequest->getBody()->__toString());
+        $this->assertEquals('Content', $request->getContent()); // check if getContent() can be called multiple times
 
         $queryParams = $psrRequest->getQueryParams();
         $this->assertEquals('1', $queryParams['foo']);

--- a/Tests/Factory/DiactorosFactoryTest.php
+++ b/Tests/Factory/DiactorosFactoryTest.php
@@ -114,7 +114,8 @@ class DiactorosFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetContentCanBeCalledAfterRequestCreation()
     {
-        $request = new Request(array(), array(), array(), array(), array(), array(), 'Content');
+        $header = array('HTTP_HOST' => 'dunglas.fr');
+        $request = new Request(array(), array(), array(), array(), array(), $header, 'Content');
 
         $psrRequest = $this->factory->createRequest($request);
 


### PR DESCRIPTION
The Symfony request throws a LogicException if getContent() is called more than once and the first time with parameter "true". If $symfonyRequest->getContent(true) has thrown the exception, the call to $symfonyRequest->getContent() will do the same again.