### PR TITLE
Use Zend\Diactoros\PhpInputStream for request body

### DIFF
--- a/Factory/DiactorosFactory.php
+++ b/Factory/DiactorosFactory.php
@@ -50,13 +50,11 @@ class DiactorosFactory implements HttpMessageFactoryInterface
         $bodyStreamMetaData = stream_get_meta_data($bodyStream);
         if('php://input' == $bodyStreamMetaData['uri']) {
             $body = new PhpInputStream($bodyStream);
+        } else if (PHP_VERSION_ID < 50600) {
+            $body = new DiactorosStream('php://temp', 'wb+');
+            $body->write($symfonyRequest->getContent());
         } else {
-            if (PHP_VERSION_ID < 50600) {
-                $body = new DiactorosStream('php://temp', 'wb+');
-                $body->write($symfonyRequest->getContent());
-            } else {
-                $body = new DiactorosStream($bodyStream);
-            }
+            $body = new DiactorosStream($bodyStream);
         }
 
         $request = new ServerRequest(

--- a/Tests/Factory/DiactorosFactoryTest.php
+++ b/Tests/Factory/DiactorosFactoryTest.php
@@ -111,7 +111,7 @@ class DiactorosFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('2.8'), $psrRequest->getHeader('X-Symfony'));
     }
 
-    public function testGetContentCanBeCalledAfterRequestCreation()
+    public function testGetContentCanBeCalledAfterRequestCreationWithStream()
     {
         $header = array('HTTP_HOST' => 'dunglas.fr');
         $request = new Request(array(), array(), array(), array(), array(), $header, 'Content');
@@ -120,6 +120,16 @@ class DiactorosFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Content', $psrRequest->getBody()->__toString());
         $this->assertEquals('Content', $request->getContent());
+    }
+
+    public function testGetBodyWillReturnPhpInputStreamByDefault()
+    {
+        $header = array('HTTP_HOST' => 'dunglas.fr');
+        $request = new Request(array(), array(), array(), array(), array(), $header, null);
+
+        $psrRequest = $this->factory->createRequest($request);
+
+        $this->assertInstanceOf('Zend\Diactoros\PhpInputStream', $psrRequest->getBody());
     }
 
     private function createUploadedFile($content, $originalName, $mimeType, $error)


### PR DESCRIPTION
Instead of DiactorosStream we use PhpInputStream for the request body
because it can cache php://input