### PR TITLE
Fix the request target in PSR7 Request

### DIFF
--- a/Factory/DiactorosFactory.php
+++ b/Factory/DiactorosFactory.php
@@ -55,7 +55,7 @@ class DiactorosFactory implements HttpMessageFactoryInterface
         $request = new ServerRequest(
             $server,
             DiactorosRequestFactory::normalizeFiles($this->getFiles($symfonyRequest->files->all())),
-            $symfonyRequest->getUri(),
+            $symfonyRequest->getSchemeAndHttpHost().$symfonyRequest->getRequestUri(),
             $symfonyRequest->getMethod(),
             $body,
             $headers
@@ -65,6 +65,7 @@ class DiactorosFactory implements HttpMessageFactoryInterface
             ->withCookieParams($symfonyRequest->cookies->all())
             ->withQueryParams($symfonyRequest->query->all())
             ->withParsedBody($symfonyRequest->request->all())
+            ->withRequestTarget($symfonyRequest->getRequestUri())
         ;
 
         foreach ($symfonyRequest->attributes->all() as $key => $value) {

--- a/Tests/Factory/DiactorosFactoryTest.php
+++ b/Tests/Factory/DiactorosFactoryTest.php
@@ -69,6 +69,8 @@ class DiactorosFactoryTest extends TestCase
                 'REQUEST_METHOD' => 'POST',
                 'HTTP_HOST' => 'dunglas.fr',
                 'HTTP_X_SYMFONY' => '2.8',
+                'REQUEST_URI' => '/testCreateRequest?foo=1&bar[baz]=42',
+                'QUERY_STRING' => 'foo=1&bar[baz]=42',
             ),
             'Content'
         );
@@ -80,6 +82,9 @@ class DiactorosFactoryTest extends TestCase
         $queryParams = $psrRequest->getQueryParams();
         $this->assertEquals('1', $queryParams['foo']);
         $this->assertEquals('42', $queryParams['bar']['baz']);
+
+        $requestTarget = $psrRequest->getRequestTarget();
+        $this->assertEquals('/testCreateRequest?foo=1&bar[baz]=42', $requestTarget);
 
         $parsedBody = $psrRequest->getParsedBody();
         $this->assertEquals('Kévin Dunglas', $parsedBody['twitter']['@dunglas']);


### PR DESCRIPTION
The request target is not being preserved correctly when using this library. This is because the query string is normalized, and we're not populating the PSR-7 request with the actual request target.

This is important for things like http signatures which uses the request target as an input to sign a request.