### PR TITLE
Add support for streamed response

### DIFF
--- a/Factory/HttpFoundationFactory.php
+++ b/Factory/HttpFoundationFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PsrHttpMessage\Factory;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * {@inheritdoc}
@@ -28,6 +30,16 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class HttpFoundationFactory implements HttpFoundationFactoryInterface
 {
+    /**
+     * @var int The maximum output buffering size for each iteration when sending the response
+     */
+    private $responseBufferMaxLength;
+
+    public function __construct(int $responseBufferMaxLength = 16372)
+    {
+        $this->responseBufferMaxLength = $responseBufferMaxLength;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -138,16 +150,25 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createResponse(ResponseInterface $psrResponse)
+    public function createResponse(ResponseInterface $psrResponse, bool $streamed = false)
     {
         $cookies = $psrResponse->getHeader('Set-Cookie');
         $psrResponse = $psrResponse->withHeader('Set-Cookie', []);
 
-        $response = new Response(
-            $psrResponse->getBody()->__toString(),
-            $psrResponse->getStatusCode(),
-            $psrResponse->getHeaders()
-        );
+        if ($streamed) {
+            $response = new StreamedResponse(
+                $this->createStreamedResponseCallback($psrResponse->getBody()),
+                $psrResponse->getStatusCode(),
+                $psrResponse->getHeaders()
+            );
+        } else {
+            $response = new Response(
+                $psrResponse->getBody()->__toString(),
+                $psrResponse->getStatusCode(),
+                $psrResponse->getHeaders()
+            );
+        }
+
         $response->setProtocolVersion($psrResponse->getProtocolVersion());
 
         foreach ($cookies as $cookie) {
@@ -236,5 +257,24 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
             false,
             isset($samesite) ? $samesite : null
         );
+    }
+
+    private function createStreamedResponseCallback(StreamInterface $body): callable
+    {
+        return function () use ($body) {
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+
+            if (!$body->isReadable()) {
+                echo $body;
+
+                return;
+            }
+
+            while (!$body->eof()) {
+                echo $body->read($this->responseBufferMaxLength);
+            }
+        };
     }
 }

--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -237,5 +237,14 @@ class HttpFoundationFactoryTest extends TestCase
 
         $this->assertEquals('The response body', $symfonyResponse->getContent());
         $this->assertEquals(200, $symfonyResponse->getStatusCode());
+
+        $symfonyResponse = $this->factory->createResponse($response, true);
+
+        ob_start();
+        $symfonyResponse->sendContent();
+        $sentContent = ob_get_clean();
+
+        $this->assertEquals('The response body', $sentContent);
+        $this->assertEquals(200, $symfonyResponse->getStatusCode());
     }
 }

--- a/Tests/Fixtures/Stream.php
+++ b/Tests/Fixtures/Stream.php
@@ -19,6 +19,7 @@ use Psr\Http\Message\StreamInterface;
 class Stream implements StreamInterface
 {
     private $stringContent;
+    private $eof = true;
 
     public function __construct($stringContent = '')
     {
@@ -49,12 +50,12 @@ class Stream implements StreamInterface
 
     public function eof()
     {
-        return true;
+        return $this->eof;
     }
 
     public function isSeekable()
     {
-        return false;
+        return true;
     }
 
     public function seek($offset, $whence = SEEK_SET)
@@ -63,6 +64,7 @@ class Stream implements StreamInterface
 
     public function rewind()
     {
+        $this->eof = false;
     }
 
     public function isWritable()
@@ -81,6 +83,8 @@ class Stream implements StreamInterface
 
     public function read($length)
     {
+        $this->eof = true;
+
         return $this->stringContent;
     }
 


### PR DESCRIPTION
Here's a simple implementation of response streaming heavily inspired by Diactoros' response emitter, using HttpFoundation's `StreamedResponse`. It lacks support for `Content-Range`, but I can provide that in a future PR.

Closes https://github.com/symfony/psr-http-message-bridge/issues/3