### PR TITLE
Marked zendframework/zend-diactoros >= 2.0.0 as conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "require-dev": {
         "symfony/phpunit-bridge": "^3.4 || 4.0"
     },
+    "conflict": {
+        "zendframework/zend-diactoros": ">= 2.0.0"
+    },
     "suggest": {
         "psr/http-message-implementation": "To use the HttpFoundation factory",
         "zendframework/zend-diactoros": "To use the Zend Diactoros factory",


### PR DESCRIPTION
This is a temporary solution for https://github.com/symfony/psr-http-message-bridge/issues/51

While `symfony/psr-http-message-bridge` is not upgraded to support the `zendframework/zend-diactoros >= 2` it makes sense to prevent installing it at all.