### PR TITLE
Add support for streamed Symfony request

### DIFF
--- a/Factory/DiactorosFactory.php
+++ b/Factory/DiactorosFactory.php
@@ -84,8 +84,6 @@ class DiactorosFactory implements HttpMessageFactoryInterface
     /**
      * Converts Symfony uploaded files array to the PSR one.
      *
-     * @param array $uploadedFiles
-     *
      * @return array
      */
     private function getFiles(array $uploadedFiles)
@@ -109,8 +107,6 @@ class DiactorosFactory implements HttpMessageFactoryInterface
 
     /**
      * Creates a PSR-7 UploadedFile instance from a Symfony one.
-     *
-     * @param UploadedFile $symfonyUploadedFile
      *
      * @return UploadedFileInterface
      */

--- a/Factory/HttpFoundationFactory.php
+++ b/Factory/HttpFoundationFactory.php
@@ -43,7 +43,7 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createRequest(ServerRequestInterface $psrRequest)
+    public function createRequest(ServerRequestInterface $psrRequest, bool $streamed = false)
     {
         $server = [];
         $uri = $psrRequest->getUri();
@@ -69,7 +69,7 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
             $psrRequest->getCookieParams(),
             $this->getFiles($psrRequest->getUploadedFiles()),
             $server,
-            $psrRequest->getBody()->__toString()
+            $streamed ? $psrRequest->getBody()->detach() : $psrRequest->getBody()->__toString()
         );
         $request->headers->replace($psrRequest->getHeaders());
 
@@ -78,8 +78,6 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
 
     /**
      * Converts to the input array to $_FILES structure.
-     *
-     * @param array $uploadedFiles
      *
      * @return array
      */
@@ -100,8 +98,6 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
 
     /**
      * Creates Symfony UploadedFile instance from PSR-7 ones.
-     *
-     * @param UploadedFileInterface $psrUploadedFile
      *
      * @return UploadedFile
      */
@@ -183,13 +179,11 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
      *
      * Some snippets have been taken from the Guzzle project: https://github.com/guzzle/guzzle/blob/5.3/src/Cookie/SetCookie.php#L34
      *
-     * @param string $cookie
-     *
      * @return Cookie
      *
      * @throws \InvalidArgumentException
      */
-    private function createCookie($cookie)
+    private function createCookie(string $cookie)
     {
         foreach (explode(';', $cookie) as $part) {
             $part = trim($part);

--- a/Factory/PsrHttpFactory.php
+++ b/Factory/PsrHttpFactory.php
@@ -78,8 +78,6 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
     /**
      * Converts Symfony uploaded files array to the PSR one.
      *
-     * @param array $uploadedFiles
-     *
      * @return array
      */
     private function getFiles(array $uploadedFiles)
@@ -103,8 +101,6 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
 
     /**
      * Creates a PSR-7 UploadedFile instance from a Symfony one.
-     *
-     * @param UploadedFile $symfonyUploadedFile
      *
      * @return UploadedFileInterface
      */

--- a/HttpFoundationFactoryInterface.php
+++ b/HttpFoundationFactoryInterface.php
@@ -26,18 +26,14 @@ interface HttpFoundationFactoryInterface
     /**
      * Creates a Symfony Request instance from a PSR-7 one.
      *
-     * @param ServerRequestInterface $psrRequest
-     *
      * @return Request
      */
-    public function createRequest(ServerRequestInterface $psrRequest);
+    public function createRequest(ServerRequestInterface $psrRequest, bool $streamed = false);
 
     /**
      * Creates a Symfony Response instance from a PSR-7 one.
      *
-     * @param ResponseInterface $psrResponse
-     *
      * @return Response
      */
-    public function createResponse(ResponseInterface $psrResponse);
+    public function createResponse(ResponseInterface $psrResponse, bool $streamed = false);
 }

--- a/HttpMessageFactoryInterface.php
+++ b/HttpMessageFactoryInterface.php
@@ -26,16 +26,12 @@ interface HttpMessageFactoryInterface
     /**
      * Creates a PSR-7 Request instance from a Symfony one.
      *
-     * @param Request $symfonyRequest
-     *
      * @return ServerRequestInterface
      */
     public function createRequest(Request $symfonyRequest);
 
     /**
      * Creates a PSR-7 Response instance from a Symfony one.
-     *
-     * @param Response $symfonyResponse
      *
      * @return ResponseInterface
      */

--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -83,6 +83,27 @@ class HttpFoundationFactoryTest extends TestCase
         $this->assertEquals(['a', 'b'], $symfonyRequest->headers->get('X-data', null, false));
     }
 
+    public function testCreateRequestWithStreamedBody()
+    {
+        $serverRequest = new ServerRequest(
+            '1.1',
+            [],
+            new Stream('The body'),
+            '/',
+            'GET',
+            null,
+            [],
+            [],
+            [],
+            [],
+            null,
+            []
+        );
+
+        $symfonyRequest = $this->factory->createRequest($serverRequest, true);
+        $this->assertEquals('The body', $symfonyRequest->getContent());
+    }
+
     public function testCreateRequestWithNullParsedBody()
     {
         $serverRequest = new ServerRequest(

--- a/Tests/Fixtures/Stream.php
+++ b/Tests/Fixtures/Stream.php
@@ -37,6 +37,7 @@ class Stream implements StreamInterface
 
     public function detach()
     {
+        return fopen('data://text/plain,'.$this->stringContent, 'r');
     }
 
     public function getSize()


### PR DESCRIPTION
As a continuation of #3 and #50 . Add support for converting a `ServerRequestInterface` with a large body to a Symfony request.

I'm not all too familiar with Symfony components, but I saw that a Symfony request supports `string|resource|null` as its body. Since calling `detach()` on a `StreamInterface` will make the stream unsuable I added a `$streamed` argument to the function in order to not make break any existing code, and to make it a conscious decision of the caller to stream the response.

I'm happy to make any necessary changes if needed.