### PR TITLE
Don't use moveTo() when dealing with uploaded files

### DIFF
--- a/Factory/HttpFoundationFactory.php
+++ b/Factory/HttpFoundationFactory.php
@@ -111,7 +111,20 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
         $clientFileName = '';
         if (UPLOAD_ERR_NO_FILE !== $psrUploadedFile->getError()) {
             $temporaryPath = $this->getTemporaryPath();
-            $psrUploadedFile->moveTo($temporaryPath);
+
+            $stream = $psrUploadedFile->getStream();
+            $originalPosition = $stream->tell();
+            $isSeekable = $stream->isSeekable();
+
+            if ($isSeekable) {
+                $stream->rewind();
+            }
+
+            file_put_contents($temporaryPath, $stream->getContents());
+
+            if ($isSeekable) {
+                $stream->seek($originalPosition);
+            }
 
             $clientFileName = $psrUploadedFile->getClientFilename();
         }

--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -174,6 +174,15 @@ class HttpFoundationFactoryTest extends TestCase
         $symfonyUploadedFile->move($this->tmpDir, 'shouldFail.txt');
     }
 
+    public function testCreateUploadedFileTwice()
+    {
+        $uploadedFile = $this->createUploadedFile('An uploaded file.', UPLOAD_ERR_OK, 'myfile.txt', 'text/plain');
+        $symfonyUploadedFile = $this->callCreateUploadedFile($uploadedFile);
+        $symfonyUploadedFile2 = $this->callCreateUploadedFile($uploadedFile);
+
+        $this->assertEquals($symfonyUploadedFile2->getSize(), $symfonyUploadedFile->getSize());
+    }
+
     private function createUploadedFile($content, $error, $clientFileName, $clientMediaType)
     {
         $filePath = tempnam($this->tmpDir, uniqid());

--- a/Tests/Fixtures/UploadedFile.php
+++ b/Tests/Fixtures/UploadedFile.php
@@ -35,7 +35,7 @@ class UploadedFile implements UploadedFileInterface
 
     public function getStream()
     {
-        throw new \RuntimeException('No stream is available.');
+        return new Stream(file_get_contents($this->filePath));
     }
 
     public function moveTo($targetPath)


### PR DESCRIPTION
As discussed in #15, `HttpFoundationFactory` calls `UploadedFileInterface::moveTo` which effectively prevents any further manipulation with the original PSR-7 uploaded file. Instead of moving the file to the temporary directory, this patch copies it, and tries to clean up after itself if possible (i.e. if the stream is seekable, which I believe should be true in most of the usual scenarios).

It's still not optimal because it has to read the whole uploaded file into the memory. But it should be quite easy to change it to copy it in smaller chunks if a more considerate approach is desired.

Also related to #39 