### PR TITLE
Replace deprecated package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4 || ^5.0",
         "nyholm/psr7": "^1.1",
-        "zendframework/zend-diactoros": "^1.4.1 || ^2.0"
+        "laminas/laminas-diactoros": "^1.4.1 || ^2.0"
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"


### PR DESCRIPTION
The Zend package is deprecated. Replaced it with the new one. According to the docs, the package are the same except for the name.

- https://github.com/laminas/laminas-diactoros
- https://github.com/zendframework/zend-diactoros