### PR TITLE
Fix populating default port and headers in HttpFoundationFactory

### DIFF
--- a/Factory/HttpFoundationFactory.php
+++ b/Factory/HttpFoundationFactory.php
@@ -49,7 +49,7 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
 
         if ($uri instanceof UriInterface) {
             $server['SERVER_NAME'] = $uri->getHost();
-            $server['SERVER_PORT'] = $uri->getPort();
+            $server['SERVER_PORT'] = $uri->getPort() ?: ('https' === $uri->getScheme() ? 443 : 80);
             $server['REQUEST_URI'] = $uri->getPath();
             $server['QUERY_STRING'] = $uri->getQuery();
 
@@ -74,7 +74,7 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
             $server,
             $streamed ? $psrRequest->getBody()->detach() : $psrRequest->getBody()->__toString()
         );
-        $request->headers->replace($psrRequest->getHeaders());
+        $request->headers->add($psrRequest->getHeaders());
 
         return $request;
     }


### PR DESCRIPTION
These are few dirty hacks which are required to get symfony up and running as Roadrunner psr7 worker:
 - overriding headers need to be removed to be able to send basic auth headers.
 - setting `$_SERVER['https']` to true is required for properly handling non-proxied requests, handled with encryption directly from Roadrunner - same as https://github.com/symfony/psr-http-message-bridge/pull/77
 - setting default server port fixes error with interpreting no port defined in url as `0`
