### PR TITLE
Fix BinaryFileResponse with range to psr response conversion

### DIFF
--- a/Factory/PsrHttpFactory.php
+++ b/Factory/PsrHttpFactory.php
@@ -127,13 +127,13 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
     {
         $response = $this->responseFactory->createResponse($symfonyResponse->getStatusCode(), Response::$statusTexts[$symfonyResponse->getStatusCode()] ?? '');
 
-        if ($symfonyResponse instanceof BinaryFileResponse) {
+        if ($symfonyResponse instanceof BinaryFileResponse && !$symfonyResponse->headers->has('Content-Range')) {
             $stream = $this->streamFactory->createStreamFromFile(
                 $symfonyResponse->getFile()->getPathname()
             );
         } else {
             $stream = $this->streamFactory->createStreamFromFile('php://temp', 'wb+');
-            if ($symfonyResponse instanceof StreamedResponse) {
+            if ($symfonyResponse instanceof StreamedResponse || $symfonyResponse instanceof BinaryFileResponse) {
                 ob_start(function ($buffer) use ($stream) {
                     $stream->write($buffer);
 

--- a/Tests/Factory/AbstractHttpMessageFactoryTest.php
+++ b/Tests/Factory/AbstractHttpMessageFactoryTest.php
@@ -182,6 +182,23 @@ abstract class AbstractHttpMessageFactoryTest extends TestCase
         $this->assertEquals('Binary', $psrResponse->getBody()->__toString());
     }
 
+    public function testCreateResponseFromBinaryFileWithRange()
+    {
+        $path = tempnam($this->tmpDir, uniqid());
+        file_put_contents($path, 'Binary');
+
+        $request = new Request();
+        $request->headers->set('Range', 'bytes=1-4');
+
+        $response = new BinaryFileResponse($path, 200, ['Content-Type' => 'plain/text']);
+        $response->prepare($request);
+
+        $psrResponse = $this->factory->createResponse($response);
+
+        $this->assertEquals('inar', $psrResponse->getBody()->__toString());
+        $this->assertSame('bytes 1-4/6', $psrResponse->getHeaderLine('Content-Range'));
+    }
+
     public function testUploadErrNoFile()
     {
         $file = new UploadedFile('', '', null, UPLOAD_ERR_NO_FILE, true);


### PR DESCRIPTION
Closes #84

As requested by [Fabien](https://github.com/symfony/symfony/pull/38280#issuecomment-698242033).

I think using the slightly less optimal version of checking for a `Content-Range` header is better than relying on reflection. In theory, this could be slightly sub optimal when streaming whole files and setting the `Content-Range` manually but I'm assuming that's very rare in practice.