### PR TITLE
PSR HTTP message converters for controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 phpunit.xml
 .php_cs.cache
 .phpunit.result.cache
+/Tests/Fixtures/App/var

--- a/ArgumentValueResolver/PsrServerRequestResolver.php
+++ b/ArgumentValueResolver/PsrServerRequestResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+/**
+ * Injects the RequestInterface, MessageInterface or ServerRequestInterface when requested.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class PsrServerRequestResolver implements ArgumentValueResolverInterface
+{
+    private const SUPPORTED_TYPES = [
+        ServerRequestInterface::class => true,
+        RequestInterface::class => true,
+        MessageInterface::class => true,
+    ];
+
+    private $httpMessageFactory;
+
+    public function __construct(HttpMessageFactoryInterface $httpMessageFactory)
+    {
+        $this->httpMessageFactory = $httpMessageFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        return self::SUPPORTED_TYPES[$argument->getType()] ?? false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument): \Traversable
+    {
+        yield $this->httpMessageFactory->createRequest($request);
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+# 2.1.0 (2021-02-17)
+
+  * Added a `PsrResponseListener` to automatically convert PSR-7 responses returned by controllers
+  * Added a `PsrServerRequestResolver` that allows injecting PSR-7 request objects into controllers
+
 # 2.0.2 (2020-09-29)
 
   * Fix populating server params from URI in HttpFoundationFactory

--- a/EventListener/PsrResponseListener.php
+++ b/EventListener/PsrResponseListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\EventListener;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Converts PSR-7 Response to HttpFoundation Response using the bridge.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class PsrResponseListener implements EventSubscriberInterface
+{
+    private $httpFoundationFactory;
+
+    public function __construct(HttpFoundationFactoryInterface $httpFoundationFactory = null)
+    {
+        $this->httpFoundationFactory = $httpFoundationFactory ?? new HttpFoundationFactory();
+    }
+
+    /**
+     * Do the conversion if applicable and update the response of the event.
+     */
+    public function onKernelView(ViewEvent $event): void
+    {
+        $controllerResult = $event->getControllerResult();
+
+        if (!$controllerResult instanceof ResponseInterface) {
+            return;
+        }
+
+        $event->setResponse($this->httpFoundationFactory->createResponse($controllerResult));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::VIEW => 'onKernelView',
+        ];
+    }
+}

--- a/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
+++ b/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\ArgumentValueResolver;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class PsrServerRequestResolverTest extends TestCase
+{
+    public function testServerRequest()
+    {
+        $symfonyRequest = $this->createMock(Request::class);
+        $psrRequest = $this->createMock(ServerRequestInterface::class);
+
+        $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
+
+        self::assertSame([$psrRequest], $resolver->getArguments($symfonyRequest, static function (ServerRequestInterface $serverRequest): void {}));
+    }
+
+    public function testRequest()
+    {
+        $symfonyRequest = $this->createMock(Request::class);
+        $psrRequest = $this->createMock(ServerRequestInterface::class);
+
+        $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
+
+        self::assertSame([$psrRequest], $resolver->getArguments($symfonyRequest, static function (RequestInterface $request): void {}));
+    }
+
+    public function testMessage()
+    {
+        $symfonyRequest = $this->createMock(Request::class);
+        $psrRequest = $this->createMock(ServerRequestInterface::class);
+
+        $resolver = $this->bootstrapResolver($symfonyRequest, $psrRequest);
+
+        self::assertSame([$psrRequest], $resolver->getArguments($symfonyRequest, static function (MessageInterface $request): void {}));
+    }
+
+    private function bootstrapResolver(Request $symfonyRequest, ServerRequestInterface $psrRequest): ArgumentResolver
+    {
+        $messageFactory = $this->createMock(HttpMessageFactoryInterface::class);
+        $messageFactory->expects(self::once())
+            ->method('createRequest')
+            ->with(self::identicalTo($symfonyRequest))
+            ->willReturn($psrRequest);
+
+        return new ArgumentResolver(null, [new PsrServerRequestResolver($messageFactory)]);
+    }
+}

--- a/Tests/EventListener/PsrResponseListenerTest.php
+++ b/Tests/EventListener/PsrResponseListenerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class PsrResponseListenerTest extends TestCase
+{
+    public function testConvertsControllerResult()
+    {
+        $listener = new PsrResponseListener();
+        $event = $this->createEventMock(new Response());
+        $listener->onKernelView($event);
+
+        self::assertTrue($event->hasResponse());
+    }
+
+    public function testDoesNotConvertControllerResult()
+    {
+        $listener = new PsrResponseListener();
+        $event = $this->createEventMock([]);
+
+        $listener->onKernelView($event);
+        self::assertFalse($event->hasResponse());
+
+        $event = $this->createEventMock(null);
+
+        $listener->onKernelView($event);
+        self::assertFalse($event->hasResponse());
+    }
+
+    private function createEventMock($controllerResult): ViewEvent
+    {
+        return new ViewEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST, $controllerResult);
+    }
+}

--- a/Tests/Fixtures/App/Controller/PsrRequestController.php
+++ b/Tests/Fixtures/App/Controller/PsrRequestController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Controller;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class PsrRequestController
+{
+    private $responseFactory;
+    private $streamFactory;
+
+    public function __construct(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    public function serverRequestAction(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse()
+            ->withBody($this->streamFactory->createStream(sprintf('<html><body>%s</body></html>', $request->getMethod())));
+    }
+
+    public function requestAction(RequestInterface $request): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse()
+            ->withStatus(403)
+            ->withBody($this->streamFactory->createStream(sprintf('<html><body>%s %s</body></html>', $request->getMethod(), $request->getBody()->getContents())));
+    }
+
+    public function messageAction(MessageInterface $request): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse()
+            ->withStatus(422)
+            ->withBody($this->streamFactory->createStream(sprintf('<html><body>%s</body></html>', $request->getHeader('X-My-Header')[0])));
+    }
+}

--- a/Tests/Fixtures/App/Kernel.php
+++ b/Tests/Fixtures/App/Kernel.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
+use Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Controller\PsrRequestController;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends SymfonyKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes
+            ->add('server_request', '/server-request')->controller([PsrRequestController::class, 'serverRequestAction'])->methods(['GET'])
+            ->add('request', '/request')->controller([PsrRequestController::class, 'requestAction'])->methods(['POST'])
+            ->add('message', '/message')->controller([PsrRequestController::class, 'messageAction'])->methods(['PUT'])
+        ;
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->extension('framework', [
+            'router' => ['utf8' => true],
+            'secret' => 'for your eyes only',
+            'test' => true,
+        ]);
+
+        $container->services()
+            ->set('nyholm.psr_factory', Psr17Factory::class)
+            ->alias(ResponseFactoryInterface::class, 'nyholm.psr_factory')
+            ->alias(ServerRequestFactoryInterface::class, 'nyholm.psr_factory')
+            ->alias(StreamFactoryInterface::class, 'nyholm.psr_factory')
+            ->alias(UploadedFileFactoryInterface::class, 'nyholm.psr_factory')
+        ;
+
+        $container->services()
+            ->defaults()->autowire()->autoconfigure()
+            ->set(HttpFoundationFactoryInterface::class, HttpFoundationFactory::class)
+            ->set(HttpMessageFactoryInterface::class, PsrHttpFactory::class)
+            ->set(PsrResponseListener::class)
+            ->set(PsrServerRequestResolver::class)
+        ;
+
+        $container->services()
+            ->set('logger', NullLogger::class)
+            ->set(PsrRequestController::class)->public()->autowire()
+        ;
+    }
+}

--- a/Tests/Fixtures/App/Kernel44.php
+++ b/Tests/Fixtures/App/Kernel44.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
+use Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Controller\PsrRequestController;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+class Kernel44 extends SymfonyKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $routes->add('/server-request', PsrRequestController::class.'::serverRequestAction')->setMethods(['GET']);
+        $routes->add('/request', PsrRequestController::class.'::requestAction')->setMethods(['POST']);
+        $routes->add('/message', PsrRequestController::class.'::messageAction')->setMethods(['PUT']);
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $container->loadFromExtension('framework', [
+            'secret' => 'for your eyes only',
+            'test' => true,
+        ]);
+
+        $container->register('nyholm.psr_factory', Psr17Factory::class);
+        $container->setAlias(ResponseFactoryInterface::class, 'nyholm.psr_factory');
+        $container->setAlias(ServerRequestFactoryInterface::class, 'nyholm.psr_factory');
+        $container->setAlias(StreamFactoryInterface::class, 'nyholm.psr_factory');
+        $container->setAlias(UploadedFileFactoryInterface::class, 'nyholm.psr_factory');
+
+        $container->register(HttpFoundationFactoryInterface::class, HttpFoundationFactory::class)->setAutowired(true)->setAutoconfigured(true);
+        $container->register(HttpMessageFactoryInterface::class, PsrHttpFactory::class)->setAutowired(true)->setAutoconfigured(true);
+        $container->register(PsrResponseListener::class)->setAutowired(true)->setAutoconfigured(true);
+        $container->register(PsrServerRequestResolver::class)->setAutowired(true)->setAutoconfigured(true);
+
+        $container->register('logger', NullLogger::class);
+        $container->register(PsrRequestController::class)->setPublic(true)->setAutowired(true);
+    }
+}

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Functional;
+
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Kernel;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Kernel44;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class ControllerTest extends WebTestCase
+{
+    public function testServerRequestAction()
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', '/server-request');
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('GET', $crawler->text());
+    }
+
+    public function testRequestAction()
+    {
+        $client = self::createClient();
+        $crawler = $client->request('POST', '/request', [], [], [], 'some content');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertSame('POST some content', $crawler->text());
+    }
+
+    public function testMessageAction()
+    {
+        $client = self::createClient();
+        $crawler = $client->request('PUT', '/message', [], [], ['HTTP_X_MY_HEADER' => 'some content']);
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertSame('some content', $crawler->text());
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return SymfonyKernel::VERSION_ID >= 50200 ? Kernel::class : Kernel44::class;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,14 @@
         "symfony/http-foundation": "^4.4 || ^5.0"
     },
     "require-dev": {
+        "symfony/browser-kit": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
         "symfony/phpunit-bridge": "^4.4.19 || ^5.2",
-        "nyholm/psr7": "^1.1"
+        "nyholm/psr7": "^1.1",
+        "psr/log": "^1.1"
     },
     "suggest": {
         "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
@@ -35,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.0-dev"
+            "dev-main": "2.1-dev"
         }
     }
 }


### PR DESCRIPTION
This PR proposes to add two classes to `symfony/psr-http-message-bridge` that have been removed from `sensio/framework-extra-bundle`.

By adding `PsrServerRequestResolver` and `PsrResponseListener` to its service container, with autowring and autoconfiguring enabled, an application gains the ability to operate controllers on PSR-7 message objects instead of HttpFoundation.

This is especially useful if a developer wants to reuse generic packages like `league/oauth2-server`.

Configuration files for autowiring the two classes can be provided as Flex recipes.