### PR TITLE
remove link to sensio extra bundle which removed psr7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Resources
 ---------
 
   * [Documentation](https://symfony.com/doc/current/components/psr7.html)
-  * [SensioFrameworkExtraBundle](https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html#psr-7-support)
 
 Running the tests
 -----------------


### PR DESCRIPTION
The documentation that has been removed in extra bundle in https://github.com/sensiolabs/SensioFrameworkExtraBundle/commit/8c9318d79226516943c02fd983d94770c17a562e should probably be added to the bridge now.