### PR TITLE
Leverage `Request::getPayload()` to populate the parsed body of PSR-7 requests

### DIFF
--- a/Tests/Factory/PsrHttpFactoryTest.php
+++ b/Tests/Factory/PsrHttpFactoryTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Antonio J. García Lagar <aj@garcialagar.es>
+ * @author Aurélien Pillevesse <aurelienpillevesse@hotmail.fr>
  */
 class PsrHttpFactoryTest extends TestCase
 {
@@ -242,5 +243,53 @@ class PsrHttpFactoryTest extends TestCase
 
         $this->assertSame(\UPLOAD_ERR_NO_FILE, $uploadedFiles['f1']->getError());
         $this->assertSame(\UPLOAD_ERR_NO_FILE, $uploadedFiles['f2']->getError());
+    }
+
+    public function testJsonContent()
+    {
+        if (!method_exists(Request::class, 'getPayload')) {
+            $this->markTestSkipped();
+        }
+
+        $headers = [
+            'HTTP_HOST' => 'http_host.fr',
+            'CONTENT_TYPE' => 'application/json',
+        ];
+        $request = new Request([], [], [], [], [], $headers, '{"city":"Paris","country":"France"}');
+        $psrRequest = $this->factory->createRequest($request);
+
+        $this->assertSame(['city' => 'Paris', 'country' => 'France'], $psrRequest->getParsedBody());
+    }
+
+    public function testEmptyJsonContent()
+    {
+        if (!method_exists(Request::class, 'getPayload')) {
+            $this->markTestSkipped();
+        }
+
+        $headers = [
+            'HTTP_HOST' => 'http_host.fr',
+            'CONTENT_TYPE' => 'application/json',
+        ];
+        $request = new Request([], [], [], [], [], $headers, '{}');
+        $psrRequest = $this->factory->createRequest($request);
+
+        $this->assertSame([], $psrRequest->getParsedBody());
+    }
+
+    public function testWrongJsonContent()
+    {
+        if (!method_exists(Request::class, 'getPayload')) {
+            $this->markTestSkipped();
+        }
+
+        $headers = [
+            'HTTP_HOST' => 'http_host.fr',
+            'CONTENT_TYPE' => 'application/json',
+        ];
+        $request = new Request([], [], [], [], [], $headers, '{"city":"Paris"');
+        $psrRequest = $this->factory->createRequest($request);
+
+        $this->assertSame([], $psrRequest->getParsedBody());
     }
 }


### PR DESCRIPTION
I'm trying to send a ```POST``` request with the fields below and ```application/x-www-form-urlencoded``` header : 
- "city": "Paris"
- "country": "France"

If I send it like that, the fields are understood and I have these fields when I display the Request :
- [ "city": "Paris", "country": "France" ]

 

Now if I send the same ```POST``` request with ```application/json``` header (with the same fields but in ```JSON``` format) : 
- {"city":"Paris","country":"France"}

They are not understand and I have an empty Request : 
- []