### PR TITLE
Add native types where possible

### DIFF
--- a/Factory/HttpFoundationFactory.php
+++ b/Factory/HttpFoundationFactory.php
@@ -41,6 +41,8 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return Request
      */
     public function createRequest(ServerRequestInterface $psrRequest, bool $streamed = false)
     {
@@ -121,6 +123,8 @@ class HttpFoundationFactory implements HttpFoundationFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return Response
      */
     public function createResponse(ResponseInterface $psrResponse, bool $streamed = false)
     {

--- a/Factory/PsrHttpFactory.php
+++ b/Factory/PsrHttpFactory.php
@@ -12,7 +12,9 @@
 namespace Symfony\Bridge\PsrHttpMessage\Factory;
 
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -45,6 +47,8 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return ServerRequestInterface
      */
     public function createRequest(Request $symfonyRequest)
     {
@@ -84,10 +88,8 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
 
     /**
      * Converts Symfony uploaded files array to the PSR one.
-     *
-     * @return array
      */
-    private function getFiles(array $uploadedFiles)
+    private function getFiles(array $uploadedFiles): array
     {
         $files = [];
 
@@ -108,10 +110,8 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
 
     /**
      * Creates a PSR-7 UploadedFile instance from a Symfony one.
-     *
-     * @return UploadedFileInterface
      */
-    private function createUploadedFile(UploadedFile $symfonyUploadedFile)
+    private function createUploadedFile(UploadedFile $symfonyUploadedFile): UploadedFileInterface
     {
         return $this->uploadedFileFactory->createUploadedFile(
             $this->streamFactory->createStreamFromFile(
@@ -126,6 +126,8 @@ class PsrHttpFactory implements HttpMessageFactoryInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return ResponseInterface
      */
     public function createResponse(Response $symfonyResponse)
     {

--- a/Factory/UploadedFile.php
+++ b/Factory/UploadedFile.php
@@ -52,7 +52,7 @@ class UploadedFile extends BaseUploadedFile
     /**
      * {@inheritdoc}
      */
-    public function move($directory, $name = null): File
+    public function move(string $directory, string $name = null): File
     {
         if (!$this->isValid() || $this->test) {
             return parent::move($directory, $name);

--- a/Tests/EventListener/PsrResponseListenerTest.php
+++ b/Tests/EventListener/PsrResponseListenerTest.php
@@ -46,6 +46,9 @@ class PsrResponseListenerTest extends TestCase
         self::assertFalse($event->hasResponse());
     }
 
+    /**
+     * @param mixed $controllerResult
+     */
     private function createEventMock($controllerResult): ViewEvent
     {
         return new ViewEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST, $controllerResult);

--- a/Tests/Factory/HttpFoundationFactoryTest.php
+++ b/Tests/Factory/HttpFoundationFactoryTest.php
@@ -196,7 +196,7 @@ class HttpFoundationFactoryTest extends TestCase
         $symfonyUploadedFile->move($this->tmpDir, 'shouldFail.txt');
     }
 
-    private function createUploadedFile($content, $error, $clientFileName, $clientMediaType): UploadedFile
+    private function createUploadedFile(string $content, int $error, string $clientFileName, string $clientMediaType): UploadedFile
     {
         $filePath = tempnam($this->tmpDir, uniqid());
         file_put_contents($filePath, $content);

--- a/Tests/Factory/PsrHttpFactoryTest.php
+++ b/Tests/Factory/PsrHttpFactoryTest.php
@@ -28,7 +28,10 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class PsrHttpFactoryTest extends TestCase
 {
+    /** @var HttpMessageFactoryInterface */
     private $factory;
+
+    /** @var string */
     private $tmpDir;
 
     protected function buildHttpMessageFactory(): HttpMessageFactoryInterface
@@ -135,7 +138,7 @@ class PsrHttpFactoryTest extends TestCase
         $this->assertSame('Content', $request->getContent());
     }
 
-    private function createUploadedFile($content, $originalName, $mimeType, $error)
+    private function createUploadedFile(string $content, string $originalName, string $mimeType, int $error): UploadedFile
     {
         $path = tempnam($this->tmpDir, uniqid());
         file_put_contents($path, $content);

--- a/Tests/Fixtures/Message.php
+++ b/Tests/Fixtures/Message.php
@@ -25,7 +25,7 @@ class Message implements MessageInterface
     private $headers = [];
     private $body;
 
-    public function __construct($version = '1.1', array $headers = [], StreamInterface $body = null)
+    public function __construct(string $version = '1.1', array $headers = [], StreamInterface $body = null)
     {
         $this->version = $version;
         $this->headers = $headers;

--- a/Tests/Fixtures/Response.php
+++ b/Tests/Fixtures/Response.php
@@ -21,7 +21,7 @@ class Response extends Message implements ResponseInterface
 {
     private $statusCode;
 
-    public function __construct($version = '1.1', array $headers = [], StreamInterface $body = null, $statusCode = 200)
+    public function __construct(string $version = '1.1', array $headers = [], StreamInterface $body = null, int $statusCode = 200)
     {
         parent::__construct($version, $headers, $body);
 

--- a/Tests/Fixtures/ServerRequest.php
+++ b/Tests/Fixtures/ServerRequest.php
@@ -31,7 +31,11 @@ class ServerRequest extends Message implements ServerRequestInterface
     private $data;
     private $attributes;
 
-    public function __construct($version = '1.1', array $headers = [], StreamInterface $body = null, $requestTarget = '/', $method = 'GET', $uri = null, array $server = [], array $cookies = [], array $query = [], array $uploadedFiles = [], $data = null, array $attributes = [])
+    /**
+     * @param UriInterface|string|null $uri
+     * @param array|object|null        $data
+     */
+    public function __construct(string $version = '1.1', array $headers = [], StreamInterface $body = null, string $requestTarget = '/', string $method = 'GET', $uri = null, array $server = [], array $cookies = [], array $query = [], array $uploadedFiles = [], $data = null, array $attributes = [])
     {
         parent::__construct($version, $headers, $body);
 

--- a/Tests/Fixtures/Stream.php
+++ b/Tests/Fixtures/Stream.php
@@ -21,7 +21,7 @@ class Stream implements StreamInterface
     private $stringContent;
     private $eof = true;
 
-    public function __construct($stringContent = '')
+    public function __construct(string $stringContent = '')
     {
         $this->stringContent = $stringContent;
     }

--- a/Tests/Fixtures/UploadedFile.php
+++ b/Tests/Fixtures/UploadedFile.php
@@ -25,7 +25,7 @@ class UploadedFile implements UploadedFileInterface
     private $clientFileName;
     private $clientMediaType;
 
-    public function __construct($filePath, $size = null, $error = \UPLOAD_ERR_OK, $clientFileName = null, $clientMediaType = null)
+    public function __construct(string $filePath, int $size = null, int $error = \UPLOAD_ERR_OK, string $clientFileName = null, string $clientMediaType = null)
     {
         $this->filePath = $filePath;
         $this->size = $size;

--- a/Tests/Functional/CovertTest.php
+++ b/Tests/Functional/CovertTest.php
@@ -98,7 +98,7 @@ class CovertTest extends TestCase
         }
     }
 
-    public function requestProvider()
+    public static function requestProvider(): array
     {
         $sfRequest = new Request(
             [
@@ -120,8 +120,8 @@ class CovertTest extends TestCase
                 'c2' => ['c3' => 'bar'],
             ],
             [
-                'f1' => $this->createUploadedFile('F1', 'f1.txt', 'text/plain', \UPLOAD_ERR_OK),
-                'foo' => ['f2' => $this->createUploadedFile('F2', 'f2.txt', 'text/plain', \UPLOAD_ERR_OK)],
+                'f1' => self::createUploadedFile('F1', 'f1.txt', 'text/plain', \UPLOAD_ERR_OK),
+                'foo' => ['f2' => self::createUploadedFile('F2', 'f2.txt', 'text/plain', \UPLOAD_ERR_OK)],
             ],
             [
                 'REQUEST_METHOD' => 'POST',
@@ -195,7 +195,7 @@ class CovertTest extends TestCase
         }
     }
 
-    public function responseProvider()
+    public static function responseProvider(): array
     {
         $sfResponse = new Response(
             'Response content.',
@@ -227,7 +227,7 @@ class CovertTest extends TestCase
         ];
     }
 
-    private function createUploadedFile($content, $originalName, $mimeType, $error)
+    private static function createUploadedFile(string $content, string $originalName, string $mimeType, int $error): UploadedFile
     {
         $path = tempnam(sys_get_temp_dir(), uniqid());
         file_put_contents($path, $content);


### PR DESCRIPTION
This PR improves the typing throughout the codebase:

* Native types are added where possible without a BC break
* PHPDoc`@return` annotations have been added to prevent deprecations triggered by ErrorHandler
* More PHPDoc has been added where a native type cannot be set as long as we support PHP 7.2.
* PHPUnit data providers have been declared `static`.